### PR TITLE
Fixed issue where gatsby-custom-source-api throws error about url.

### DIFF
--- a/utils/buildNode.js
+++ b/utils/buildNode.js
@@ -11,7 +11,6 @@ module.exports = ({
     children: [],
     internal: {
       type: name,
-      url: data && data.url,
       content: JSON.stringify(data),
       contentDigest: createContentDigest(data)
     }


### PR DESCRIPTION
See: https://github.com/AndreasFaust/gatsby-source-custom-api/issues/5

This fixes the problem for me and imports my API successfully into GraphQL.