### PR TITLE
add explicit resolver to fix deprecation warnings for local files in Gatsby v2

### DIFF
--- a/utils/getTypeDefs.js
+++ b/utils/getTypeDefs.js
@@ -1,5 +1,5 @@
 const getTypeDef = (name, schema, imageKeys) => {
-  const local = imageKeys.includes(name) ? 'local: File' : ''
+  const local = imageKeys.includes(name) ? 'local: File @link(by: "id", from: "local___NODE")' : ''
   return `
     type ${name} implements Node {
       ${schema}


### PR DESCRIPTION
This prepares the plugin for use with Gatsby v3 by fixing the deprecation warning in Gatsby v2 that is caused by local files:

```
warn Deprecation warning: adding inferred extension `link` for field `original.local`.

In Gatsby v3, only fields with an explicit directive/extension will be resolved correctly.
Add the following type definition to fix this:

  type original implements Node {
    local: File @link(by: "id", from: "local___NODE")
  }
```

As far as I can tell, this is not something that can be fixed by the user in `gatsby-config.js`, since it's handled internally by the plugin.