### PR TITLE
Clarify that the restricted ID issue has been handled in message

### DIFF
--- a/utils/normalizeKeys.js
+++ b/utils/normalizeKeys.js
@@ -1,7 +1,7 @@
 function isRestricted (key) {
   const restrictedKeys = ['id', 'children', 'parent', 'fields', 'internal']
   if (restrictedKeys.includes(key)) {
-    console.log(`The key "${key}" is restricted in GraphQl!`)
+    console.log(`The key "${key}" is restricted in GraphQL! Transformed to ${key}__normalized.`)
     return `${key}__normalized`
   }
   return key


### PR DESCRIPTION
It’s not clear from the message concerning restricted IDs that the issue has been handled automatically by normalization. Adding this information will prevent developers from investing time trying to bugfix the issue, since we often can’t control the endpoint that we are accessing.