### PR TITLE
By dmotan: Added gif to supported image ext.

### DIFF
--- a/utils/loadImages.js
+++ b/utils/loadImages.js
@@ -48,6 +48,7 @@ function extensionIsValid (url) {
     case 'jpg':
     case 'jpeg':
     case 'png':
+    case 'gif':
       return true
     default:
       return false


### PR DESCRIPTION
I have been getting `mage-Extension not valid` for images with `.gif`. Adding support to `.gif` extensions In this commit.