### PR TITLE
Fixed code to avoid touchnode() deprication warning.

### DIFF
--- a/utils/loadImages.js
+++ b/utils/loadImages.js
@@ -27,8 +27,11 @@ async function createImageNodes ({
   }
   if (fileNode) {
     await cache.set(imageCacheKey, {
-      fileNodeID: fileNode.id,
-      modified: entity.data.modified
+      id: fileNode.id,
+      modified: entity.data.modified,
+      internal: {
+          type: entity.name
+      }
     })
     console.log('Image downloaded: ' + imageName)
     return {
@@ -77,14 +80,14 @@ async function loadImages ({
         entity.data.modified &&
         entity.data.modified === cachedImage.modified
       ) {
-        const { fileNodeID } = cachedImage
-        touchNode({ nodeId: fileNodeID })
+        const { id } = cachedImage
+        touchNode(cachedImage)
         console.log('Image from Cache: ' + imageName)
         return Promise.resolve({
           ...entity,
           links: {
             ...entity.links,
-            local___NODE: fileNodeID
+            local___NODE: id
           }
         })
       }


### PR DESCRIPTION
Fixed the code to eliminate this warning: `warn Calling "touchNode" with an object containing the nodeId is deprecated.`

This also helps with building on Netlify, without this change, Netlify does not use the cache properly.
See https://github.com/gatsbyjs/gatsby/blob/41f0ce7ad5010b94c635ad9a08a7f4c4ba564df7/packages/gatsby/src/redux/actions/public.js#L904-L939 for reference.