### PR TITLE
Determine image extension from url with query string or hash

### DIFF
--- a/utils/loadImages.js
+++ b/utils/loadImages.js
@@ -48,7 +48,7 @@ async function createImageNodes ({
 }
 
 function extensionIsValid (url) {
-  const ext = url.split('.').pop().split('/')[0]
+  const ext = url.split(/[#?]/)[0].split('.').pop()
   switch (ext) {
     case 'jpg':
     case 'jpeg':


### PR DESCRIPTION
This updates the `extensionIsValid` function to return true for image urls that include periods in query strings or hashes that are appended to the url. For instance, Instagram image urls include periods in the query strings and so the `extensionIsValid`function returns false for these image urls.

Example image url formats that currently don't work:

- https://www.example.com/image.jpg?query=something.like.this
- https://www.example.com/image.jpg#something.like.this

