### PR TITLE
Make `auth` optional

### DIFF
--- a/utils/loadImages.js
+++ b/utils/loadImages.js
@@ -18,7 +18,7 @@ async function createImageNodes ({
   try {
     fileNode = await createRemoteFileNode({
       url: entity.data.url,
-      auth: { htaccess_user: auth.username, htaccess_pass:  auth.password },
+      auth: auth && { htaccess_user: auth.username, htaccess_pass:  auth.password },
       store,
       cache,
       createNode,


### PR DESCRIPTION
Since `auth` is optional and `loadImages` currently throws an error when there is no `auth`, this PR adds a short circuit.

Fixes #36.

I've been using `patch-package` while the last published version is broken (and it's working nicely):

```diff
diff --git a/node_modules/gatsby-source-custom-api/utils/loadImages.js b/node_modules/gatsby-source-custom-api/utils/loadImages.js
index 8c2441e..6b83100 100644
--- a/node_modules/gatsby-source-custom-api/utils/loadImages.js
+++ b/node_modules/gatsby-source-custom-api/utils/loadImages.js
@@ -18,7 +18,7 @@ async function createImageNodes ({
   try {
     fileNode = await createRemoteFileNode({
       url: entity.data.url,
-      auth: { htaccess_user: auth.username, htaccess_pass:  auth.password },
+      auth: auth && { htaccess_user: auth.username, htaccess_pass:  auth.password },
       store,
       cache,
       createNode,
```